### PR TITLE
bump optparse-applicative dep from `< 0.17` to `< 0.18`

### DIFF
--- a/nix-diff.cabal
+++ b/nix-diff.cabal
@@ -29,7 +29,7 @@ executable nix-diff
                      , directory                           < 1.4
                      , mtl                  >= 2.2      && < 2.3
                      , nix-derivation       >= 1.1      && < 1.2
-                     , optparse-applicative >= 0.14.0.0 && < 0.17
+                     , optparse-applicative >= 0.14.0.0 && < 0.18
                      , patience             >= 0.3      && < 0.4
                      , text                 >= 1.2      && < 1.3
                      , unix                                < 2.8


### PR DESCRIPTION
I just tried building `nix-diff` with the latest version of `optparse-applicative` (0.17.0.0) with ghc-9.2.4 in https://github.com/NixOS/nixpkgs/pull/202022, and it appears to build fine.

For reference, here's the build failure on Hydra before bumping the `optparse-applicative` version bound: https://hydra.nixos.org/build/200084727/nixlog/1