### PR TITLE
[#72] Fix strange GHC error when building with nixos-unstable

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,11 +38,19 @@ jobs:
         cabal:
         - '3.4'
         ghc:
+        - '9.4.4'
+        - '9.2.5'
         - '9.0.2'
         - '8.10.7'
-        - '8.8.4'
-        - '8.6.5'
+  build-nix:
+    "runs-on": "ubuntu-latest"
+    steps:
+    - uses: "actions/checkout@v3"
+    - uses: cachix/install-nix-action@v17
+      with:
+        github_access_token: ${{ secrets.GITHUB_TOKEN }}
+    - name: check it build with nix
+      run: nix build
 name: Haskell CI
 'on':
-- push
 - pull_request

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1672441588,
-        "narHash": "sha256-jx5kxOyeObnVD44HRebKYL3cjWrcKhhcDmEYm0/naDY=",
+        "lastModified": 1672953546,
+        "narHash": "sha256-oz757DnJ1ITvwyTovuwG3l9cX6j9j6/DH9eH+cXFJmc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6a0d2701705c3cf6f42c15aa92b7885f1f8a477f",
+        "rev": "a518c77148585023ff56022f09c4b2c418a51ef5",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.11",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 { inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     utils.url = "github:numtide/flake-utils";
   };
@@ -16,13 +16,13 @@
 
           haskellPackages = pkgsOld.haskellPackages.override (old: {
             overrides = self: super: {
-              nix-diff = 
+              nix-diff =
                 # There are quick check and golden tests.
                 # Quick check tests require random source to work.
                 # Golden tests require write access to the /nix/var
                 # and read access to the test data into /nix/store
                 # So we can't run these tests in build time
-                pkgsNew.haskell.lib.dontCheck 
+                pkgsNew.haskell.lib.dontCheck
                 (self.callCabal2nix "nix-diff" ./. {});
             };
           });

--- a/nix-diff.cabal
+++ b/nix-diff.cabal
@@ -12,7 +12,7 @@ maintainer:          GenuineGabriella@gmail.com
 copyright:           2017 Gabriella Gonzalez
 category:            System
 build-type:          Simple
-tested-with:         GHC == 8.0.2, GHC == 8.2.2, GHC == 8.8.3
+tested-with:         GHC == 8.10.7, GHC == 9.0.2, GHC == 9.2.5, GHC == 9.4.4
 cabal-version:       >= 1.10
 extra-source-files:  README.md
                      CHANGELOG.md
@@ -33,7 +33,7 @@ library
                      , nix-derivation       >= 1.1      && < 1.2
                      , optparse-applicative >= 0.14.0.0 && < 0.18
                      , patience             >= 0.3      && < 0.4
-                     , text                 >= 1.2      && < 1.3
+                     , text                 >= 1.2      && < 2.1
                      , vector               >= 0.12     && < 0.13
                      , process                             < 1.7
                      , filepath                            < 1.5
@@ -52,7 +52,7 @@ executable nix-diff
                      , nix-diff
                      , aeson
                      , bytestring
-                     , optparse-applicative >= 0.14.0.0 && < 0.17
+                     , optparse-applicative >= 0.14.0.0 && < 0.18
                      , text
                      , unix                                < 2.8
                      , containers

--- a/src/Nix/Diff/Types.hs
+++ b/src/Nix/Diff/Types.hs
@@ -6,10 +6,10 @@
 {-# LANGUAGE DeriveTraversable     #-}
 {-# LANGUAGE BlockArguments        #-}
 {-# LANGUAGE DerivingVia           #-}
-{-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# OPTIONS_GHC -Wno-orphans #-}
+{-# LANGUAGE DeriveDataTypeable    #-}
+{-# LANGUAGE StandaloneDeriving    #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# OPTIONS_GHC -Wno-orphans -fconstraint-solver-iterations=0 #-}
 
 module Nix.Diff.Types where
 


### PR DESCRIPTION
Problem: GHC 9.2 (for some reason) can't derive Arbitrary instances

Solution:
  - Add `-fconstraint-solver-iterations=0` GHC option
  - Update GHCs in CI and add check that we can build our project with nix