### PR TITLE
Add `--limit-context` flag

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -71,6 +71,13 @@ parseLineOriented =
             <>  Options.Applicative.help ("Display textual differences on a per-" <> x <> " basis")
             )
 
+parseLimitContext :: Parser Bool
+parseLimitContext =
+    Options.Applicative.switch
+        (   Options.Applicative.long "limit-context"
+        <>  Options.Applicative.help "Only display a few unchanged tokens surrounding changes (mostly only useful with --line-oriented)"
+        )
+
 parseEnvironment :: Parser Bool
 parseEnvironment =
     Options.Applicative.switch
@@ -112,6 +119,7 @@ data Options = Options
     , right            :: FilePath
     , color            :: Color
     , orientation      :: Orientation
+    , limitContext     :: Bool
     , environment      :: Bool
     , renderRunner     :: RenderRunner
     , transformOptions :: TransformOptions
@@ -123,6 +131,7 @@ parseOptions = do
     right       <- parseRight
     color       <- parseColor
     orientation <- parseLineOriented
+    limitContext <- parseLimitContext
     environment <- parseEnvironment
     renderRunner <- parseRenderRunner
     transformOptions <- parseTransformOptions


### PR DESCRIPTION
`nix-diff --limit-context` will now print at most 3 lines of context around each change. It's limited to 3 lines because that's all I could easily figure out how to implement, given the last time I wrote any Haskell was probably in school lessons about 5 years ago.

Is really only useful in combination with `--line-oriented`, because otherwise it will print at most 3 words or 3 characters of context, which is... probably unhelpful.

Would fix #42, but I figure you probably don't want to actually merge code this bad :) Also I did not update the tests at all.

Feel free to take the code or not; I probably do not have the motivation to figure out a better implementation of this, though, sorry.