### PR TITLE
Support relocated store; lightweight store module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased
+
+* [Support relocated Nix store](https://github.com/Gabriella439/nix-diff/pull/82)
+  * If configured through `NIX_REMOTE` environment variable.
+
 1.0.20
 
 * [Bump upper bounds](https://github.com/Gabriella439/nix-diff/pull/79)

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -26,6 +26,7 @@ import qualified Data.ByteString.Lazy.Char8
 import qualified Data.Text.IO as Text.IO
 
 import Nix.Diff
+import Nix.Diff.Store (StorePath(StorePath))
 import Nix.Diff.Types
 import Nix.Diff.Render.HumanReadable
 import Nix.Diff.Transformations
@@ -174,7 +175,7 @@ main = do
     let diffContext = DiffContext {..}
     let renderContext = RenderContext {..}
     let status = Status Data.Set.empty
-    let action = diff True left (Data.Set.singleton "out") right (Data.Set.singleton "out")
+    let action = diff True (StorePath left) (Data.Set.singleton "out") (StorePath right) (Data.Set.singleton "out")
     diffTree <- Control.Monad.State.evalStateT (Control.Monad.Reader.runReaderT (unDiff action) diffContext) status
     let diffTree' =
           transformDiff transformOptions diffTree

--- a/flake.lock
+++ b/flake.lock
@@ -16,9 +16,26 @@
         "type": "github"
       }
     },
+    "nixpkgs-golden": {
+      "locked": {
+        "lastModified": 1668266328,
+        "narHash": "sha256-+nAW+XR8nswyEnt5IkQlkrz9erTcQWBVLkhtNHxckFw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5ca8e2e9e1fa5e66a749b39261ad6bd0e07bc87f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5ca8e2e9e1fa5e66a749b39261ad6bd0e07bc87f",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "nixpkgs": "nixpkgs",
+        "nixpkgs-golden": "nixpkgs-golden",
         "utils": "utils"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -2,10 +2,13 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
+    # must match golden-tests/derivations/complex/new/flake.lock
+    nixpkgs-golden.url = "github:NixOS/nixpkgs/5ca8e2e9e1fa5e66a749b39261ad6bd0e07bc87f";
+
     utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { nixpkgs, utils, ... }:
+  outputs = inputs@{ nixpkgs, utils, ... }:
     let
       config = { };
 
@@ -22,7 +25,32 @@
               # Golden tests require write access to the /nix/var
               # and read access to the test data into /nix/store
               # So we can't run these tests in build time
-              pkgsNew.haskell.lib.dontCheck
+              pkgsNew.haskell.lib.compose.overrideCabal
+                (old: {
+                  testToolDepends = old.testToolDepends or [] ++ [
+                    pkgsNew.nix
+                  ];
+                  # For testing, we use a relocated Nix store, because the
+                  # real /nix/store in the sandbox is only accessible as files;
+                  # not a store objects (https://nixos.org/manual/nix/stable/glossary.html#gloss-store-object)
+                  # A relocated store lets us use /nix/store as the logical
+                  # storeDir, while using an arbitrary directory for storage.
+                  preCheck = ''
+                    ${old.preCheck or ""}
+                    TESTROOT="$(mktemp --tmpdir -d test-state-XXXXXX)"
+                    export NIX_BUILD_HOOK=
+                    export NIX_CONF_DIR=$TEST_ROOT/etc
+                    export NIX_LOCALSTATE_DIR=$TEST_ROOT/var
+                    export NIX_LOG_DIR=$TEST_ROOT/var/log/nix
+                    export NIX_STATE_DIR=$TEST_ROOT/var/nix
+                    export NIX_REMOTE="$TESTROOT/store"
+                    export HOME="$TESTROOT/home"
+                    mkdir -p $HOME
+                    echo "Copying pinned Nixpkgs for golden tests to relocated store $NIX_REMOTE"
+                    nix eval --expr 'builtins.path { path = ${inputs.nixpkgs-golden}; name = "source"; }' \
+                      --impure --extra-experimental-features nix-command --offline
+                  '';
+                })
                 (self.callCabal2nix "nix-diff" ./. { });
           };
         });

--- a/nix-diff.cabal
+++ b/nix-diff.cabal
@@ -20,6 +20,7 @@ extra-source-files:  README.md
 library
   exposed-modules:
     Nix.Diff
+    Nix.Diff.Store
     Nix.Diff.Types
     Nix.Diff.Transformations
     Nix.Diff.Render.HumanReadable

--- a/src/Nix/Diff.hs
+++ b/src/Nix/Diff.hs
@@ -13,7 +13,7 @@ import Control.Monad (forM)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Reader (MonadReader, ReaderT, ask)
 import Control.Monad.State (MonadState, StateT, get, put)
-import Data.Attoparsec.Text (IResult(..))
+import Data.Attoparsec.Text (IResult(..), Parser)
 import Data.List.NonEmpty (NonEmpty(..))
 import Data.Map (Map)
 import Data.Maybe (catMaybes)
@@ -37,7 +37,6 @@ import qualified Data.Text.Encoding.Error
 import qualified Data.Vector
 import qualified Nix.Derivation
 import qualified Patience
-import qualified System.Directory     as Directory
 import qualified System.FilePath      as FilePath
 import qualified System.Process       as Process
 
@@ -46,13 +45,15 @@ import Control.Monad.Fail (MonadFail)
 #endif
 
 import Nix.Diff.Types
+import Nix.Diff.Store (StorePath (StorePath, unsafeStorePathFile))
+import qualified Nix.Diff.Store       as Store
 
 newtype Status = Status { visited :: Set Diffed }
 
 data Diffed = Diffed
-    { leftDerivation  :: FilePath
+    { leftDerivation  :: StorePath
     , leftOutput      :: Set Text
-    , rightDerivation :: FilePath
+    , rightDerivation :: StorePath
     , rightOutput     :: Set Text
     } deriving (Eq, Ord)
 
@@ -88,11 +89,11 @@ data Orientation = Character | Word | Line
     Nix technically does not require that the Nix store is actually stored
     underneath `/nix/store`, but this is the overwhelmingly common use case
 -}
-derivationName :: FilePath -> Text
-derivationName = Text.dropEnd 4 . Text.drop 44 . Text.pack
+derivationName :: StorePath -> Text
+derivationName = Text.dropEnd 4 . Text.drop 44 . Text.pack . unsafeStorePathFile
 
 -- | Group paths by their name
-groupByName :: Map FilePath a -> Map Text (Map FilePath a)
+groupByName :: Map StorePath a -> Map Text (Map StorePath a)
 groupByName m = Data.Map.fromList assocs
   where
     toAssoc key = (derivationName key, Data.Map.filterWithKey predicate m)
@@ -107,11 +108,11 @@ groupByName m = Data.Map.fromList assocs
 
     > /nix/store/${32_CHARACTER_HASH}-${NAME}.drv
 -}
-buildProductName :: FilePath -> Text
-buildProductName = Text.drop 44 . Text.pack
+buildProductName :: StorePath -> Text
+buildProductName = Text.drop 44 . Text.pack . unsafeStorePathFile
 
 -- | Like `groupByName`, but for `Set`s
-groupSetsByName :: Set FilePath -> Map Text (Set FilePath)
+groupSetsByName :: Set StorePath -> Map Text (Set StorePath)
 groupSetsByName s = Data.Map.fromList (fmap toAssoc (Data.Set.toList s))
   where
     toAssoc key = (buildProductName key, Data.Set.filter predicate s)
@@ -127,12 +128,26 @@ readFileUtf8Lenient file =
     Data.Text.Encoding.decodeUtf8With Data.Text.Encoding.Error.lenientDecode
         <$> Data.ByteString.readFile file
 
+-- TODO: expose in nix-derivation
+filepathParser :: Parser FilePath
+filepathParser = do
+    text <- Nix.Derivation.textParser
+    let str = Text.unpack text
+    case (Text.uncons text, FilePath.isValid str) of
+        (Just ('/', _), True) -> do
+            return str
+        _ -> do
+            fail ("bad path ‘" <> Text.unpack text <> "’ in derivation")
+
+
 -- | Read and parse a derivation from a file
-readDerivation :: FilePath -> Diff (Derivation FilePath Text)
-readDerivation path = do
+readDerivation :: StorePath -> Diff (Derivation StorePath Text)
+readDerivation sp = do
+    path <- liftIO (Store.toPhysicalPath sp)
     let string = path
     text <- liftIO (readFileUtf8Lenient string)
-    case Data.Attoparsec.Text.parse Nix.Derivation.parseDerivation text of
+    let parser = Nix.Derivation.parseDerivationWith (StorePath <$> filepathParser) Nix.Derivation.textParser
+    case Data.Attoparsec.Text.parse parser text of
         Done _ derivation -> do
             return derivation
         _ -> do
@@ -141,11 +156,11 @@ readDerivation path = do
 -- | Read and parse a derivation from a store path that can be a derivation
 -- (.drv) or a realized path, in which case the corresponding derivation is
 -- queried.
-readInput :: FilePath -> Diff (Derivation FilePath Text)
+readInput :: StorePath -> Diff (Derivation StorePath Text)
 readInput pathAndMaybeOutput = do
-    let (path, _) = List.break (== '!') pathAndMaybeOutput
+    let (path, _) = List.break (== '!') (Store.unsafeStorePathFile pathAndMaybeOutput)
     if FilePath.isExtensionOf ".drv" path
-    then readDerivation path
+    then readDerivation (StorePath path)
     else do
         let string = path
         result <- liftIO (Process.readProcess "nix-store" [ "--query", "--deriver", string ] [])
@@ -153,7 +168,7 @@ readInput pathAndMaybeOutput = do
             [] -> fail ("Could not obtain the derivation of " ++ string)
             l : ls -> do
                 let drv_path = Data.List.NonEmpty.last (l :| ls)
-                readDerivation drv_path
+                readDerivation (StorePath drv_path)
 
 {-| Join two `Map`s on shared keys, discarding keys which are not present in
     both `Map`s
@@ -206,9 +221,9 @@ getGroupedDiff oldList newList = go $ Patience.diff oldList newList
 diffOutput
     :: Text
     -- ^ Output name
-    -> (DerivationOutput FilePath Text)
+    -> (DerivationOutput StorePath Text)
     -- ^ Left derivation outputs
-    -> (DerivationOutput FilePath Text)
+    -> (DerivationOutput StorePath Text)
     -- ^ Right derivation outputs
     -> (Maybe OutputDiff)
 diffOutput outputName leftOutput rightOutput = do
@@ -223,9 +238,9 @@ diffOutput outputName leftOutput rightOutput = do
 
 -- | Diff two sets of outputs
 diffOutputs
-    :: Map Text (DerivationOutput FilePath Text)
+    :: Map Text (DerivationOutput StorePath Text)
     -- ^ Left derivation outputs
-    -> Map Text (DerivationOutput FilePath Text)
+    -> Map Text (DerivationOutput StorePath Text)
     -- ^ Right derivation outputs
     -> OutputsDiff
 diffOutputs leftOutputs rightOutputs = do
@@ -363,9 +378,9 @@ diffEnv leftOutputs rightOutputs leftEnv rightEnv = do
 
 -- | Diff input sources
 diffSrcs
-    :: Set FilePath
+    :: Set StorePath
     -- ^ Left input sources
-    -> Set FilePath
+    -> Set StorePath
     -- ^ Right inputSources
     -> Diff SourcesDiff
 diffSrcs leftSrcs rightSrcs = do
@@ -390,12 +405,12 @@ diffSrcs leftSrcs rightSrcs = do
         case (Data.Set.toList leftExtraPaths, Data.Set.toList rightExtraPaths) of
             ([], []) -> return Nothing
             ([leftPath], [rightPath]) ->  do
-                leftExists  <- liftIO (Directory.doesFileExist leftPath)
-                rightExists <- liftIO (Directory.doesFileExist rightPath)
+                leftExists  <- liftIO (Store.doesFileExist leftPath)
+                rightExists <- liftIO (Store.doesFileExist rightPath)
                 srcContentDiff <- if leftExists && rightExists
                     then do
-                        leftText  <- liftIO (readFileUtf8Lenient leftPath)
-                        rightText <- liftIO (readFileUtf8Lenient rightPath)
+                        leftText  <- liftIO (Store.readFileUtf8Lenient leftPath)
+                        rightText <- liftIO (Store.readFileUtf8Lenient rightPath)
 
                         text <- diffText leftText rightText
                         return (Just text)
@@ -427,7 +442,7 @@ diffArgs leftArgs rightArgs = fmap ArgumentsDiff do
         let rightList = Data.Vector.toList rightArgs
         Data.List.NonEmpty.nonEmpty (Patience.diff leftList rightList)
 
-diff :: Bool -> FilePath -> Set Text -> FilePath -> Set Text -> Diff DerivationDiff
+diff :: Bool -> StorePath -> Set Text -> StorePath -> Set Text -> Diff DerivationDiff
 diff topLevel leftPath leftOutputs rightPath rightOutputs = do
     Status { visited } <- get
     let diffed = Diffed leftPath leftOutputs rightPath rightOutputs

--- a/src/Nix/Diff/Render/HumanReadable.hs
+++ b/src/Nix/Diff/Render/HumanReadable.hs
@@ -29,6 +29,7 @@ import Control.Monad.Fail (MonadFail)
 
 import Nix.Diff
 import Nix.Diff.Types
+import qualified Nix.Diff.Store as Store
 
 
 data RenderContext = RenderContext
@@ -159,7 +160,7 @@ renderDiffHumanReadable = \case
   where
     renderOutputStructure os =
       renderWith os \(sign, (OutputStructure path outputs)) -> do
-        echo (sign (Text.pack path <> renderOutputs outputs))
+        echo (sign (Store.toText path <> renderOutputs outputs))
 
     renderOutputsDiff OutputsDiff{..} = do
       ifExist extraOutputs \eo -> do
@@ -217,7 +218,7 @@ renderDiffHumanReadable = \case
       echo (explain ("The input sources named `" <> srcName <> "` differ"))
       renderWith srcFileDiff \(sign, paths) -> do
         forM_ paths \path -> do
-            echo ("    " <>  sign (Text.pack path))
+            echo ("    " <>  sign (Store.toText path))
 
     renderInputsDiff InputsDiff{..} = do
       renderInputExtraNames inputExtraNames
@@ -237,7 +238,7 @@ renderDiffHumanReadable = \case
       echo (explain ("The set of input derivations named `" <> drvName <> "` do not match"))
       renderWith extraPartsDiff \(sign, extraPaths) -> do
         forM_ (Data.Map.toList extraPaths) \(extraPath, outputs) -> do
-          echo ("    " <> sign (Text.pack extraPath <> renderOutputs outputs))
+          echo ("    " <> sign (Store.toText extraPath <> renderOutputs outputs))
 
     renderEnvDiff Nothing =
       echo (explain "Skipping environment comparison")

--- a/src/Nix/Diff/Store.hs
+++ b/src/Nix/Diff/Store.hs
@@ -24,12 +24,12 @@ import Data.Data (Data)
 import Data.Functor ((<&>))
 import qualified Data.List as L
 import Data.Text (Text)
-import qualified Data.Text
 import qualified Data.Text.Encoding
 import qualified Data.Text.Encoding.Error
 import qualified System.Directory as Directory
 import System.Environment (lookupEnv)
 import Test.QuickCheck (Arbitrary)
+import qualified Data.Text as T
 
 -- | A file path that may not exist on the true file system;
 -- needs to be looked up in a store, which may be relocated.
@@ -64,7 +64,7 @@ toPhysicalPath (StorePath p) = do
 
 -- | Convert a 'StorePath' to a 'Text' for display purposes. The path may not exist at this physical location.
 toText :: StorePath -> Text
-toText (StorePath p) = Data.Text.pack p
+toText (StorePath p) = T.pack p
 
 stripSlash :: FilePath -> FilePath
-stripSlash = reverse . dropWhile (== '/') . reverse
+stripSlash = T.unpack . T.reverse . T.dropWhile (== '/') . T.reverse . T.pack

--- a/src/Nix/Diff/Store.hs
+++ b/src/Nix/Diff/Store.hs
@@ -69,4 +69,4 @@ toText (StorePath p) = T.pack p
 stripSlash :: FilePath -> FilePath
 stripSlash s | not ("/" `L.isSuffixOf` s) = s
 stripSlash s = doIt s
-  where doIt = T.unpack . T.reverse . T.dropWhile (== '/') . T.reverse . T.pack
+  where doIt = T.unpack . T.dropWhileEnd (== '/') . T.pack

--- a/src/Nix/Diff/Store.hs
+++ b/src/Nix/Diff/Store.hs
@@ -1,0 +1,76 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE NoImportQualifiedPost #-}
+
+-- | A crude implementation of the Nix store concept.
+--
+-- For anything fancier than this, it would be best to use FFI bindings instead,
+-- such as hercules-ci-cnix-store.
+module Nix.Diff.Store
+  ( StorePath (..),
+    toPhysicalPath,
+    toText,
+    doesFileExist,
+    readFileUtf8Lenient,
+  )
+where
+
+import Control.Monad ((<=<))
+import Data.Aeson (FromJSON, FromJSONKey, ToJSON, ToJSONKey)
+import qualified Data.ByteString
+import Data.Data (Data)
+import Data.Functor ((<&>))
+import qualified Data.List as L
+import Data.Text (Text)
+import qualified Data.Text
+import qualified Data.Text.Encoding
+import qualified Data.Text.Encoding.Error
+import qualified System.Directory as Directory
+import System.Environment (lookupEnv)
+import Test.QuickCheck (Arbitrary)
+
+-- | A file path that may not exist on the true file system;
+-- needs to be looked up in a store, which may be relocated.
+--
+-- Unlike the (C++) Nix StorePath type, subpaths are allowed.
+newtype StorePath = StorePath
+  { -- | If the store is relocated, its physical location is elsewhere, and this 'FilePath' won't resolve.
+    -- Use 'toPhysicalPath'.
+    unsafeStorePathFile :: FilePath
+  }
+  deriving (Data)
+  deriving newtype (Show, Eq, Ord, ToJSON, FromJSON, ToJSONKey, FromJSONKey, Arbitrary)
+
+doesFileExist :: StorePath -> IO Bool
+doesFileExist =
+  Directory.doesFileExist <=< toPhysicalPath
+
+readFileUtf8Lenient :: StorePath -> IO Text
+readFileUtf8Lenient sp = do
+  file <- toPhysicalPath sp
+  Data.Text.Encoding.decodeUtf8With Data.Text.Encoding.Error.lenientDecode
+    <$> Data.ByteString.readFile file
+
+toPhysicalPath :: StorePath -> IO FilePath
+toPhysicalPath (StorePath p) = do
+  nixStoreDir <- lookupEnv "NIX_STORE_DIR" <&> maybe "/nix/store" stripSlash
+  nixRemoteMaybe <- lookupEnv "NIX_REMOTE" <&> fmap stripSlash
+  case nixRemoteMaybe of
+    Just nixRemote@('/':_) ->
+      pure $ replaceStart nixStoreDir (nixRemote <> "/" <> nixStoreDir) p
+    _ -> pure p
+
+-- | Convert a 'StorePath' to a 'Text' for display purposes. The path may not exist at this physical location.
+toText :: StorePath -> Text
+toText (StorePath p) = Data.Text.pack p
+
+stripSlash :: FilePath -> FilePath
+stripSlash = reverse . dropWhile (== '/') . reverse
+
+replaceStart :: String -> String -> String -> String
+replaceStart pattern replacement text =
+  case L.stripPrefix pattern text of
+    Just rest -> replacement <> rest
+    Nothing -> text

--- a/src/Nix/Diff/Store.hs
+++ b/src/Nix/Diff/Store.hs
@@ -67,4 +67,6 @@ toText :: StorePath -> Text
 toText (StorePath p) = T.pack p
 
 stripSlash :: FilePath -> FilePath
-stripSlash = T.unpack . T.reverse . T.dropWhile (== '/') . T.reverse . T.pack
+stripSlash s | not ("/" `L.isSuffixOf` s) = s
+stripSlash s = doIt s
+  where doIt = T.unpack . T.reverse . T.dropWhile (== '/') . T.reverse . T.pack

--- a/src/Nix/Diff/Store.hs
+++ b/src/Nix/Diff/Store.hs
@@ -58,8 +58,8 @@ toPhysicalPath (StorePath p) = do
   nixStoreDir <- lookupEnv "NIX_STORE_DIR" <&> maybe "/nix/store" stripSlash
   nixRemoteMaybe <- lookupEnv "NIX_REMOTE" <&> fmap stripSlash
   case nixRemoteMaybe of
-    Just nixRemote@('/':_) ->
-      pure $ replaceStart nixStoreDir (nixRemote <> "/" <> nixStoreDir) p
+    Just nixRemote | nixStoreDir `L.isPrefixOf` p -> do
+      pure $ nixRemote <> "/" <> L.dropWhile (== '/') p
     _ -> pure p
 
 -- | Convert a 'StorePath' to a 'Text' for display purposes. The path may not exist at this physical location.
@@ -68,9 +68,3 @@ toText (StorePath p) = Data.Text.pack p
 
 stripSlash :: FilePath -> FilePath
 stripSlash = reverse . dropWhile (== '/') . reverse
-
-replaceStart :: String -> String -> String -> String
-replaceStart pattern replacement text =
-  case L.stripPrefix pattern text of
-    Just rest -> replacement <> rest
-    Nothing -> text


### PR DESCRIPTION
Support relocated store when configured with the `NIX_STORE_DIR` and `NIX_REMOTE` environment variables.

This allows `nix-diff` to be used in the sandbox with instantiations in a store whose physical location is in the build directory rather than the logical `storeDir` (`/nix/store`).

This is achieved by changing introducing a `newtype StorePath` to help distinguish paths that may be logical paths rather than physical ones.
It is not a true abstraction in the sense that Nix's own store concept is, but that's ok. It makes this use case work, while still only relying on the ambient environment, requiring no types and variables for the store itself.

I plan to use this functionality for error reporting in evaluation tests that evaluate Nixpkgs for the purpose of testing Nix itself, in the context of Nixpkgs "passthru" tests and Nix's own CI setup.