### PR TITLE
Strip NIX_REMOTE query part

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,7 +43,8 @@
                     export NIX_LOCALSTATE_DIR=$TEST_ROOT/var
                     export NIX_LOG_DIR=$TEST_ROOT/var/log/nix
                     export NIX_STATE_DIR=$TEST_ROOT/var/nix
-                    export NIX_REMOTE="$TESTROOT/store"
+                    # Note the trailing question mark. It tests Nix.Diff.Store.stripQuery.
+                    export NIX_REMOTE="$TESTROOT/store?"
                     export HOME="$TESTROOT/home"
                     mkdir -p $HOME
                     echo "Copying pinned Nixpkgs for golden tests to relocated store $NIX_REMOTE"

--- a/src/Nix/Diff/Store.hs
+++ b/src/Nix/Diff/Store.hs
@@ -56,7 +56,7 @@ readFileUtf8Lenient sp = do
 toPhysicalPath :: StorePath -> IO FilePath
 toPhysicalPath (StorePath p) = do
   nixStoreDir <- lookupEnv "NIX_STORE_DIR" <&> maybe "/nix/store" stripSlash
-  nixRemoteMaybe <- lookupEnv "NIX_REMOTE" <&> fmap stripSlash
+  nixRemoteMaybe <- lookupEnv "NIX_REMOTE" <&> fmap stripQuery <&> fmap stripSlash
   case nixRemoteMaybe of
     Just nixRemote | nixStoreDir `L.isPrefixOf` p -> do
       pure $ nixRemote <> "/" <> L.dropWhile (== '/') p
@@ -65,6 +65,13 @@ toPhysicalPath (StorePath p) = do
 -- | Convert a 'StorePath' to a 'Text' for display purposes. The path may not exist at this physical location.
 toText :: StorePath -> Text
 toText (StorePath p) = T.pack p
+
+-- | `NIX_REMOTE` has a URL-like format, so we need to strip the query part.
+-- Exact details to be specified; see https://github.com/NixOS/nix/issues/10582
+stripQuery :: FilePath -> FilePath
+stripQuery p = case L.elemIndex '?' p of
+  Just i -> take i p
+  Nothing -> p
 
 stripSlash :: FilePath -> FilePath
 stripSlash s | not ("/" `L.isSuffixOf` s) = s


### PR DESCRIPTION
`NIX_REMOTE` has a URL-like format, so we need to strip the query part.
The exact details remain to be specified; see https://github.com/NixOS/nix/issues/10582, but this PR aligns with the current Nix behavior, and paths that need (un)escaping can be expected to be rare.

What this enables in practice, is to generate a store as part of a build, and then use both `nix` and `nix-diff` in a shell session with
`NIX_REMOTE=/nix/store/<hash>-foo/store?read-only=true` to analyze the result.