### PR TITLE
Fix HLint nits & typos

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# http://editorconfig.org
+root = true
+
+[*.hs]
+indent_style = space
+indent_size = 2
+
+[*.nix]
+indent_style = space
+indent_size = 2

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -2,9 +2,6 @@
 {-# LANGUAGE BlockArguments             #-}
 {-# LANGUAGE CPP                        #-}
 {-# LANGUAGE DuplicateRecordFields      #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE LambdaCase                 #-}
-{-# LANGUAGE NamedFieldPuns             #-}
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE RecordWildCards            #-}
 
@@ -47,7 +44,7 @@ parseColor =
     Options.Applicative.option
         reader
         (   Options.Applicative.long "color"
-        <>  Options.Applicative.help ("display colors always, automatically (if terminal detected), or never")
+        <>  Options.Applicative.help "display colors always, automatically (if terminal detected), or never"
         <>  Options.Applicative.value Auto
         <>  Options.Applicative.metavar "(always|auto|never)"
         )

--- a/src/Nix/Diff.hs
+++ b/src/Nix/Diff.hs
@@ -14,6 +14,7 @@ import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Reader (MonadReader, ReaderT, ask)
 import Control.Monad.State (MonadState, StateT, get, put)
 import Data.Attoparsec.Text (IResult(..), Parser)
+import qualified Data.Functor as Functor (unzip)
 import Data.List.NonEmpty (NonEmpty(..))
 import Data.Map (Map)
 import Data.Maybe (catMaybes)
@@ -52,9 +53,9 @@ newtype Status = Status { visited :: Set Diffed }
 
 data Diffed = Diffed
     { leftDerivation  :: StorePath
-    , leftOutput      :: Set Text
+    , leftOutput      :: Outputs
     , rightDerivation :: StorePath
-    , rightOutput     :: Set Text
+    , rightOutput     :: Outputs
     } deriving (Eq, Ord)
 
 newtype Diff a = Diff { unDiff :: ReaderT DiffContext (StateT Status IO) a }
@@ -145,7 +146,7 @@ readDerivation sp = do
     path <- liftIO (Store.toPhysicalPath sp)
     let string = path
     text <- liftIO (readFileUtf8Lenient string)
-    let parser = Nix.Derivation.parseDerivationWith (storepathParser) Nix.Derivation.textParser
+    let parser = Nix.Derivation.parseDerivationWith storepathParser Nix.Derivation.textParser
     case Data.Attoparsec.Text.parse parser text of
         Done _ derivation -> do
             return derivation
@@ -212,11 +213,11 @@ getGroupedDiff oldList newList = go $ Patience.diff oldList newList
 diffOutput
     :: Text
     -- ^ Output name
-    -> (DerivationOutput StorePath Text)
+    -> DerivationOutput StorePath Text
     -- ^ Left derivation outputs
-    -> (DerivationOutput StorePath Text)
+    -> DerivationOutput StorePath Text
     -- ^ Right derivation outputs
-    -> (Maybe OutputDiff)
+    -> Maybe OutputDiff
 diffOutput outputName leftOutput rightOutput = do
     -- We deliberately do not include output paths or hashes in the diff since
     -- we already expect them to differ if the inputs differ.  Instead, we focus
@@ -328,9 +329,9 @@ diffText left right = do
 
 -- | Diff two environments
 diffEnv
-    :: Set Text
+    :: Outputs
     -- ^ Left derivation outputs
-    -> Set Text
+    -> Outputs
     -- ^ Right derivation outputs
     -> Map Text Text
     -- ^ Left environment to compare
@@ -384,7 +385,7 @@ diffSrcs leftSrcs rightSrcs = do
     let leftExtraNames  = Data.Set.difference leftNames  rightNames
     let rightExtraNames = Data.Set.difference rightNames leftNames
 
-    let extraSrcNames = if (leftNames /= rightNames)
+    let extraSrcNames = if leftNames /= rightNames
         then Just (Changed leftExtraNames rightExtraNames)
         else Nothing
 
@@ -433,7 +434,20 @@ diffArgs leftArgs rightArgs = fmap ArgumentsDiff do
         let rightList = Data.Vector.toList rightArgs
         Data.List.NonEmpty.nonEmpty (Patience.diff leftList rightList)
 
-diff :: Bool -> StorePath -> Set Text -> StorePath -> Set Text -> Diff DerivationDiff
+diff :: Bool
+     -- ^ Is this the top-level call for a comparison?
+     --
+     -- If so, the diff will be more detailed.
+     -> StorePath
+     -- ^ Store path of left derivation.
+     -> Outputs
+     -- ^ Output names of left derivation.
+     -> StorePath
+     -- ^ Store path of right derivation.
+     -> Outputs
+     -- ^ Output names of right derivation.
+     -> Diff DerivationDiff
+     -- ^ Description of how the two derivations differ.
 diff topLevel leftPath leftOutputs rightPath rightOutputs = do
     Status { visited } <- get
     let diffed = Diffed leftPath leftOutputs rightPath rightOutputs
@@ -487,12 +501,12 @@ diff topLevel leftPath leftOutputs rightPath rightOutputs = do
             let leftExtraNames  = Data.Set.difference leftNames  rightNames
             let rightExtraNames = Data.Set.difference rightNames leftNames
 
-            let inputExtraNames = if (leftNames /= rightNames)
+            let inputExtraNames = if leftNames /= rightNames
                 then Just (Changed leftExtraNames rightExtraNames)
                 else Nothing
 
             let assocs = Data.Map.toList (innerJoin leftInputs rightInputs)
-            (descended, mInputsDiff) <- unzip <$> forM assocs \(inputName, (leftPaths, rightPaths)) -> do
+            (descended, mInputsDiff) <- Functor.unzip <$> forM assocs \(inputName, (leftPaths, rightPaths)) -> do
                 let leftExtraPaths =
                         Data.Map.difference leftPaths  rightPaths
                 let rightExtraPaths =

--- a/src/Nix/Diff/Render/HumanReadable.hs
+++ b/src/Nix/Diff/Render/HumanReadable.hs
@@ -13,7 +13,6 @@ module Nix.Diff.Render.HumanReadable where
 import Control.Monad (forM_)
 import Control.Monad.Reader (MonadReader, ReaderT (runReaderT), ask, local)
 import Control.Monad.Writer(MonadWriter, Writer, tell, runWriter)
-import Data.Set (Set)
 import Data.Text (Text)
 import Numeric.Natural (Natural)
 
@@ -131,7 +130,7 @@ renderWith Changed{..} k = do
     k (plus  tty, now)
 
 -- | Format the derivation outputs
-renderOutputs :: Set Text -> Text
+renderOutputs :: Outputs -> Text
 renderOutputs outputs =
     ":{" <> Text.intercalate "," (Data.Set.toList outputs) <> "}"
 
@@ -160,7 +159,7 @@ renderDiffHumanReadable = \case
 
   where
     renderOutputStructure os =
-      renderWith os \(sign, (OutputStructure path outputs)) -> do
+      renderWith os \(sign, OutputStructure path outputs) -> do
         echo (sign (Store.toText path <> renderOutputs outputs))
 
     renderOutputsDiff OutputsDiff{..} = do

--- a/src/Nix/Diff/Transformations.hs
+++ b/src/Nix/Diff/Transformations.hs
@@ -26,7 +26,7 @@ import Nix.Diff.Types
           • These two derivations have already been compared
     ```
     This transformation will fold all these subtrees of diff
-    into one OnlyAlreadComparedBelow.
+    into one OnlyAlreadyComparedBelow.
 -}
 foldAlreadyComparedSubTrees :: DerivationDiff -> DerivationDiff
 foldAlreadyComparedSubTrees dd = case dd of

--- a/src/Nix/Diff/Types.hs
+++ b/src/Nix/Diff/Types.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE RecordWildCards       #-}
 {-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE DerivingStrategies    #-}
 {-# LANGUAGE DeriveAnyClass        #-}
 {-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE DeriveTraversable     #-}
@@ -67,7 +66,7 @@ instance ToJSON TextDiff where
 instance FromJSON TextDiff where
   parseJSON v = TextDiff <$> (traverse itemFromJSON =<< parseJSON v)
 
--- Helpfull aliases
+-- Helpful aliases
 
 type OutputHash = Text
 
@@ -76,6 +75,9 @@ type Platform = Text
 type Builder = Text
 
 type Argument = Text
+
+-- | A set of Nix derivation output names.
+type Outputs = Set Text
 
 -- Derivation diff
 
@@ -107,7 +109,7 @@ data DerivationDiff
 
 data OutputStructure = OutputStructure
   { derivationPath :: StorePath
-  , derivationOutputs :: Set Text
+  , derivationOutputs :: Outputs
   }
   deriving stock (Eq, Show, Generic, Data)
   deriving anyclass (ToJSON, FromJSON)
@@ -237,7 +239,7 @@ data InputDerivationsDiff
       }
   | SomeDerivationsDiff
       { drvName :: Text
-      , extraPartsDiff :: Changed (Map StorePath (Set Text))
+      , extraPartsDiff :: Changed (Map StorePath Outputs)
       }
   deriving stock (Eq, Show, Generic, Data)
   deriving anyclass (ToJSON, FromJSON)


### PR DESCRIPTION
- Add `.editorconfig` so my editor knows how much to indent Haskell files in this repository
- Fix HLint nits, which were distracting with haskell-language-server
- Fix a couple typos
- Add documentation for a couple functions/parameters
- Add an `Outputs` type alias to make it clearer what some of the `Set Text` values represent