### PR TITLE
Fix tests on non-x86_64-linux

### DIFF
--- a/golden-tests/derivations/simple/new/drv.nix
+++ b/golden-tests/derivations/simple/new/drv.nix
@@ -9,24 +9,24 @@ let
     name = "second_derivation";
     derivations = [ one ];
     builder = "builder";
-    system = builtins.currentSystem;
+    system = "x86_64-linux";
   };
   three = derivation {
     name = "third_derivation";
     derivations = [ one ];
     builder = "builder";
-    system = builtins.currentSystem;
+    system = "x86_64-linux";
   };
   namesMissmatch = derivation {
     name = "new";
     builder = "builder";
-    system = builtins.currentSystem;
+    system = "x86_64-linux";
   };
   outputsMissmatch = derivation {
     name = "outputs";
     outputs = [ "lib" "headers" "doc" ];
     builder = "builder";
-    system = builtins.currentSystem;
+    system = "x86_64-linux";
   };
 in
 derivation {
@@ -35,5 +35,5 @@ derivation {
   srcs = [ ./changed-file ./new-file ];
   derivations = [ two three namesMissmatch outputsMissmatch ];
   args = [ "one" "three" "four" ];
-  system = builtins.currentSystem;
+  system = "x86_64-linux";
 }

--- a/golden-tests/derivations/simple/old/drv.nix
+++ b/golden-tests/derivations/simple/old/drv.nix
@@ -9,24 +9,24 @@ let
     name = "second_derivation";
     derivations = [ one ];
     builder = "builder";
-    system = builtins.currentSystem;
+    system = "x86_64-linux";
   };
   three = derivation {
     name = "third_derivation";
     derivations = [ one ];
     builder = "builder";
-    system = builtins.currentSystem;
+    system = "x86_64-linux";
   };
   namesMissmatch = derivation {
     name = "old";
     builder = "builder";
-    system = builtins.currentSystem;
+    system = "x86_64-linux";
   };
   outputsMissmatch = derivation {
     name = "outputs";
     outputs = [ "out" "bin" ];
     builder = "builder";
-    system = builtins.currentSystem;
+    system = "x86_64-linux";
   };
 in
 derivation {
@@ -35,5 +35,5 @@ derivation {
   srcs = [ ./changed-file ./missing-file ];
   derivations = [ two three namesMissmatch outputsMissmatch ];
   args = [ "one" "two" "three" ];
-  system = builtins.currentSystem;
+  system = "x86_64-linux";
 }

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,6 +1,7 @@
 module Main where
 
 import Test.Tasty
+import Test.Tasty.Silver.Interactive (interactiveTests)
 
 import Golden.Utils (initSimpleDerivations, initComplexDerivations)
 import Golden.Tests (goldenTests)
@@ -10,5 +11,7 @@ main :: IO ()
 main = do
   simpleTd  <- initSimpleDerivations
   complexTd <- initComplexDerivations
-  defaultMain $
-     testGroup "Tests" [goldenTests simpleTd complexTd, properties]
+  defaultMainWithIngredients
+    [ interactiveTests (const False)
+    ]
+    $ testGroup "Tests" [goldenTests simpleTd complexTd, properties]


### PR DESCRIPTION
- `builtins.currentSystem` isn't predictable, let's use `x86_64-linux` for consistency
- Add `interactiveTests` so that tasty-silver can actually show you the diff when golden tests fail