### PR TITLE
Fix JSON instances for `OutputNames`

### DIFF
--- a/src/Nix/Diff/Types.hs
+++ b/src/Nix/Diff/Types.hs
@@ -79,9 +79,8 @@ type Argument = Text
 
 -- | A set of Nix derivation output names.
 newtype OutputNames = OutputNames {unOutputNames :: Set Text}
-  deriving newtype (Eq, Ord)
+  deriving newtype (Eq, Ord, ToJSON, FromJSON)
   deriving stock (Show, Generic, Data)
-  deriving anyclass (ToJSON, FromJSON)
   deriving Arbitrary via GenericArbitrary OutputNames
 
 -- Derivation diff


### PR DESCRIPTION
We want `deriving newtype` so that we use the `Set Text` representation and not `{"unOutputNames": [...]}`.

Related: #88