### PR TITLE
Fix build for latest haskell-updates

### DIFF
--- a/nix-diff.cabal
+++ b/nix-diff.cabal
@@ -62,7 +62,7 @@ library
                      , vector               >= 0.12     && < 0.14
                      , process                             < 1.7
                      , filepath                            < 1.5
-                     , QuickCheck                          < 2.15
+                     , QuickCheck                          < 2.16
                      , quickcheck-instances                < 3.29
                      , generic-arbitrary                   < 1.1
                      , uniplate                            < 1.17

--- a/nix-diff.cabal
+++ b/nix-diff.cabal
@@ -61,7 +61,7 @@ library
                      , text                 >= 1.2      && < 2.2
                      , vector               >= 0.12     && < 0.14
                      , process                             < 1.7
-                     , filepath                            < 1.5
+                     , filepath                            < 1.6
                      , QuickCheck                          < 2.16
                      , quickcheck-instances                < 3.29
                      , generic-arbitrary                   < 1.1


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/429810

This loosens the dependency requirements for QuickCheck and and filepath. Tested building nix-diff still worked after these changes.